### PR TITLE
Cleanup ODBC-Core

### DIFF
--- a/ODBC-Core/ODBCAbstractRow.class.st
+++ b/ODBC-Core/ODBCAbstractRow.class.st
@@ -26,13 +26,19 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
+{ #category : #testing }
+ODBCAbstractRow class >> isAbstract [
+
+	^ self == ODBCAbstractRow
+]
+
 { #category : #comparing }
 ODBCAbstractRow >> = comparand [
 	"Answer whether the receiver and the <Object>, comparand, 
 	are considered equivalent."
 
-	^comparand species == self species and: [
-		self contents = comparand contents]
+	^ comparand species == self species and: [ 
+		  self contents = comparand contents ]
 ]
 
 { #category : #converting }
@@ -54,8 +60,8 @@ ODBCAbstractRow >> at: aString ifAbsent: exceptionHandler [
 	"Answer the field named aString from the receiver.  If the field is not present,
 	answer the result of evaluating the niladic valuable, exceptionHandler."
 
-	^self 
-		atIndex: (self selectors at: aString ifAbsent: [^exceptionHandler value])
+	^ self atIndex:
+		  (self selectors at: aString ifAbsent: [ ^ exceptionHandler value ])
 ]
 
 { #category : #accessing }
@@ -64,7 +70,7 @@ ODBCAbstractRow >> at: key ifPresent: operation [
 	the argument, key, is the key of an element in the receiver, with that
 	element as its argument. If the key is not present, then answer nil."
 
-	^operation value: (self at: key ifAbsent: [^nil])
+	^ operation value: (self at: key ifAbsent: [ ^ nil ])
 ]
 
 { #category : #accessing }
@@ -154,8 +160,7 @@ ODBCAbstractRow >> isDeletedRow [
 
 { #category : #printing }
 ODBCAbstractRow >> printOn: aStream [
-	"Append the ASCII representation of the receiver
-	 to aStream."
+	"Append the ASCII representation of the receiver to aStream."
 
 	aStream
 		nextPutAll: 'a ';
@@ -170,11 +175,12 @@ ODBCAbstractRow >> selectors [
 	"Private - Answer a <LookupTable> mapping the names of fields in the receiver to
 	column indices."
 
-	selectors isNil ifTrue: [self buildSelectors].
-	^selectors
+	selectors ifNil: [ self buildSelectors ].
+	^ selectors
 ]
 
 { #category : #accessing }
 ODBCAbstractRow >> status [
-	^status
+
+	^ status
 ]

--- a/ODBC-Core/ODBCAbstractStatement.class.st
+++ b/ODBC-Core/ODBCAbstractStatement.class.st
@@ -28,7 +28,7 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
-{ #category : #initializing }
+{ #category : #'class initialization' }
 ODBCAbstractStatement class >> initialize [
 	"
 		self initialize
@@ -40,6 +40,12 @@ ODBCAbstractStatement class >> initialize [
 		at: #forwardOnly put: SQL_CURSOR_FORWARD_ONLY;
 		at: #keysetDriven put: SQL_CURSOR_KEYSET_DRIVEN;
 		at: #dynamic put: SQL_CURSOR_DYNAMIC
+]
+
+{ #category : #testing }
+ODBCAbstractStatement class >> isAbstract [
+
+	^self == ODBCAbstractStatement
 ]
 
 { #category : #'instance creation' }
@@ -154,7 +160,8 @@ ODBCAbstractStatement >> cursorType [
 ]
 
 { #category : #accessing }
-ODBCAbstractStatement >> cursorType: aSymbol [ 
+ODBCAbstractStatement >> cursorType: aSymbol [
+
 	(CursorTypes includesKey: aSymbol) 
 		ifFalse: [self error: 'Invalid cursor type ' , aSymbol].
 	cursorType := aSymbol.
@@ -281,7 +288,7 @@ ODBCAbstractStatement >> exceptionDetails: anIntegerRetCode [
 
 	^(self parent exceptionDetails: anIntegerRetCode)
 		hStmt: handle;
-		yourself.
+		yourself
 ]
 
 { #category : #operations }
@@ -289,7 +296,7 @@ ODBCAbstractStatement >> exec [
 	"Private - Execute the tables query the receiver represents."
 
 	self dbCheckException: self executeStatement.
-	executed := true.
+	executed := true
 ]
 
 { #category : #operations }
@@ -314,7 +321,6 @@ ODBCAbstractStatement >> executedHandle [
 
 { #category : #accessing }
 ODBCAbstractStatement >> finalizationRegistry [
-
 	"Use the parent's statements WeakRegistry"
 	
 	^parent statements
@@ -354,6 +360,7 @@ ODBCAbstractStatement >> getStringAttribute: anInteger [
 
 { #category : #accessing }
 ODBCAbstractStatement >> handle [
+
 	^handle
 ]
 

--- a/ODBC-Core/ODBCColAttr.class.st
+++ b/ODBC-Core/ODBCColAttr.class.st
@@ -38,7 +38,7 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
-{ #category : #initializing }
+{ #category : #'class initialization' }
 ODBCColAttr class >> initialize [
 	"Private - Initialize the receiver's class variables.
 		self initialize
@@ -81,7 +81,7 @@ ODBCColAttr class >> initialize [
 	self initializeExtraBytes 
 ]
 
-{ #category : #initializing }
+{ #category : #'private - initialization' }
 ODBCColAttr class >> initializeExtraBytes [
 
 	| extraBytes |

--- a/ODBC-Core/ODBCColFlags.class.st
+++ b/ODBC-Core/ODBCColFlags.class.st
@@ -21,80 +21,92 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
-{ #category : #'pool initialization' }
+{ #category : #'private - pool initialization' }
 ODBCColFlags class >> initialize [
+
 	self
-		initialize_DeleteCascade;
-		initialize_DeleteRestrict;
-		initialize_DeleteRules;
-		initialize_DeleteSetNull;
-		initialize_ForeignKey;
-		initialize_ParameterTypeMask;
-		initialize_ParameterTypeShift;
-		initialize_PrimaryKey;
-		initialize_UpdateCascade;
-		initialize_UpdateRestrict;
-		initialize_UpdateRules;
-		initialize_UpdateSetNull;
-		yourself
+		initializeDeleteCascade;
+		initializeDeleteRestrict;
+		initializeDeleteRules;
+		initializeDeleteSetNull;
+		initializeForeignKey;
+		initializeParameterTypeMask;
+		initializeParameterTypeShift;
+		initializePrimaryKey;
+		initializeUpdateCascade;
+		initializeUpdateRestrict;
+		initializeUpdateRules;
+		initializeUpdateSetNull 
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_DeleteCascade [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeDeleteCascade [
+
 	DeleteCascade := 16
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_DeleteRestrict [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeDeleteRestrict [
+
 	DeleteRestrict := 32
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_DeleteRules [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeDeleteRules [
+
 	DeleteRules := 112
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_DeleteSetNull [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeDeleteSetNull [
+
 	DeleteSetNull := 64
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_ForeignKey [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeForeignKey [
+
 	ForeignKey := 2
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_ParameterTypeMask [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeParameterTypeMask [
+
 	ParameterTypeMask := 14336
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_ParameterTypeShift [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeParameterTypeShift [
+
 	ParameterTypeShift := 11
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_PrimaryKey [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializePrimaryKey [
+
 	PrimaryKey := 1
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_UpdateCascade [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeUpdateCascade [
+
 	UpdateCascade := 256
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_UpdateRestrict [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeUpdateRestrict [
+
 	UpdateRestrict := 512
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_UpdateRules [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeUpdateRules [
+
 	UpdateRules := 1792
 ]
 
-{ #category : #'pool initialization' }
-ODBCColFlags class >> initialize_UpdateSetNull [
+{ #category : #'private - pool initialization' }
+ODBCColFlags class >> initializeUpdateSetNull [
+
 	UpdateSetNull := 1024
 ]

--- a/ODBC-Core/ODBCConnection.class.st
+++ b/ODBC-Core/ODBCConnection.class.st
@@ -105,7 +105,7 @@ ODBCConnection class >> dbCheckException: anIntegerRetCode [
 				ifFalse: [ODBCError]) signalWith: (self exceptionDetails: anIntegerRetCode)]
 ]
 
-{ #category : #initializing }
+{ #category : #'class initialization' }
 ODBCConnection class >> determineStringEncoder [
 
 	"The String encoding can vary depending on the ODBC driver manager:
@@ -258,8 +258,9 @@ ODBCConnection class >> freeAll [
 	connections will be closed, etc.!"
 
 	self connections do: [:each | each free].
-	self newConnections.
-	self freeEnvironment
+	self 
+		newConnections;
+		freeEnvironment
 ]
 
 { #category : #'realizing/unrealizing' }
@@ -274,11 +275,9 @@ ODBCConnection class >> freeEnvironment [
 			HEnv := nil]
 ]
 
-{ #category : #initializing }
+{ #category : #'class initialization' }
 ODBCConnection class >> initialize [
-	"Private - Initialize the receiver's class variable.s
-		self initialize
-	"
+	"Private - Initialize the receiver's class variables"
 
 	DriverCompleteMask := 1.
 	TxnIsolationLevels := (IdentityDictionary new)
@@ -297,7 +296,7 @@ ODBCConnection class >> initialize [
 	self newConnections
 ]
 
-{ #category : #initializing }
+{ #category : #'class initialization' }
 ODBCConnection class >> initializeStringEncoder [
 
 	self determineStringEncoder.
@@ -378,7 +377,7 @@ ODBCConnection class >> transact: aDBConnection action: anInteger [
 				sqlEndTran: SQL_HANDLE_DBC
 				handle: aDBConnection asParameter
 				completionType: anInteger.
-	ret ~= SQL_SUCCESS ifTrue: [ODBCError signalWith: (aDBConnection exceptionDetails: ret)].
+	ret ~= SQL_SUCCESS ifTrue: [ODBCError signalWith: (aDBConnection exceptionDetails: ret)]
 ]
 
 { #category : #helpers }
@@ -405,15 +404,14 @@ ODBCConnection >> asParameter [
 	"Answer the receiver in a form suitable for passing to an external function
 	primitive method (see ExternalLibrary and subclasses)."
 
-	handle isNull ifTrue: [self basicConnect].
-	^handle
+	handle isNull ifTrue: [ self basicConnect ].
+	^ handle
 ]
 
 { #category : #operations }
 ODBCConnection >> basicConnect [
 	"Private - Connect with the parameters specified earlier.
 	Assumes not already connected."
-
 	
 	[| ret |
 	ret := ODBCLibrary default 
@@ -425,7 +423,7 @@ ODBCConnection >> basicConnect [
 				authentication: (self stringEncoder encodeStringWithNullTerminator: pwd)
 				nameLength3: SQL_NTS.
 	self dbCheckException: ret] 
-			ifCurtailed: [self free]
+			ifCurtailed: [ self free ]
 ]
 
 { #category : #transactions }
@@ -444,6 +442,7 @@ ODBCConnection >> beginTxn [
 
 { #category : #helpers }
 ODBCConnection >> buildConnectString [
+
 	| stream |
 	stream := WriteStream on: (String new: 50).
 	dsn notNil 
@@ -468,7 +467,7 @@ ODBCConnection >> buildConnectString [
 ODBCConnection >> catalogNameSeparator [
 	"Answer the qualifier name separator"
 
-	^self getStringInfo: SQL_CATALOG_NAME_SEPARATOR
+	^ self getStringInfo: SQL_CATALOG_NAME_SEPARATOR
 ]
 
 { #category : #enquiries }
@@ -476,17 +475,17 @@ ODBCConnection >> catalogTerm [
 	"Answer the <readableString> name for a 'catalog' in the parlance of the DBMS to which the
 	receiver is connected, e.g. in the case of Access this is 'DATABASE'."
 
-	^self getStringInfo: SQL_CATALOG_TERM
+	^ self getStringInfo: SQL_CATALOG_TERM
 ]
 
 { #category : #helpers }
 ODBCConnection >> checkEmptyEnvironment [
 	"Private - If there are no more open connections, free the environment"
 
-	Connections isEmpty
-		ifTrue: [
-			[self class freeEnvironment] on: ODBCError do: [:se | se trace].
-			HEnv := nil].
+	Connections ifNotEmpty: [ ^self ].
+
+	[ self class freeEnvironment] on: ODBCError do: [:se | se trace].
+	HEnv := nil
 ]
 
 { #category : #operations }
@@ -494,14 +493,13 @@ ODBCConnection >> close [
 	"Close a database connection - rollback the current transaction, disconnect,
 	and free connection handle"
 
-	handle isNull
-		ifFalse: [
-			transaction notNil
-				ifTrue: [self rollbackTxn].
-			self
-				disconnect;
-				free;
-				checkEmptyEnvironment]
+	handle isNull ifTrue: [ ^self ].
+
+	transaction ifNotNil: [ self rollbackTxn ].	
+	self
+		disconnect;
+		free;
+		checkEmptyEnvironment
 ]
 
 { #category : #operations }
@@ -509,10 +507,12 @@ ODBCConnection >> closeNoFail [
 	"Quietly close connection (frees handle), and if no
 	more open connections, free the environment"
 
-	[self close] on: ODBCError do: [ :se |
-		se trace.
-		handle := SQLHANDLE null.
-		self checkEmptyEnvironment]
+	[ self close ]
+		on: ODBCError
+		do: [ :se | 
+			se trace.
+			handle := SQLHANDLE null.
+			self checkEmptyEnvironment ]
 ]
 
 { #category : #accessing }

--- a/ODBC-Core/ODBCError.class.st
+++ b/ODBC-Core/ODBCError.class.st
@@ -20,13 +20,6 @@ ODBCError class >> signalWith: anODBCExceptionDetails [
 	self signal: anODBCExceptionDetails displayString withTag: anODBCExceptionDetails
 ]
 
-{ #category : #displaying }
-ODBCError >> _descriptionFormat [
-	"Answer the Win32 format String to be used to format the description for the receiver."
-	
-	^'%1 %2'
-]
-
 { #category : #signalling }
 ODBCError >> signal [
 	"Signal this exception."

--- a/ODBC-Core/ODBCErrorDetails.class.st
+++ b/ODBC-Core/ODBCErrorDetails.class.st
@@ -39,9 +39,9 @@ ODBCErrorDetails >> messageText [
 	"Answer a text representation of the error of the form:
 		STATE: MSG"
 
-	^(sqlState isNil 
-		ifTrue: ['']
-		ifFalse: [sqlState, ': ']), msg
+	^ (sqlState 
+			ifNil: [ '' ] 
+			ifNotNil: [ sqlState , ': ' ]) , msg
 ]
 
 { #category : #accessing }
@@ -69,7 +69,7 @@ ODBCErrorDetails >> nativeErr: aString [
 ODBCErrorDetails >> origin: aString [
 	"Private - Set the origin instance variable to aString."
 
-	origin := aString.
+	origin := aString
 ]
 
 { #category : #accessing }

--- a/ODBC-Core/ODBCExceptionDetails.class.st
+++ b/ODBC-Core/ODBCExceptionDetails.class.st
@@ -34,8 +34,8 @@ Class {
 ODBCExceptionDetails >> addErrorDetails: newErrorDetails [
 	"Private - Add a new error details object to my collection."
 
-	errors isNil ifTrue: [self errors: OrderedCollection new].
-	errors addLast: newErrorDetails.
+	errors ifNil: [ self errors: OrderedCollection new ].
+	errors addLast: newErrorDetails
 ]
 
 { #category : #operations }
@@ -49,7 +49,7 @@ ODBCExceptionDetails >> buildErrorInfo [
 			[hEnv isNull ifFalse: [self buildErrorInfoFrom: hEnv type: SQL_HANDLE_ENV].
 			hDBC isNull ifFalse: [self buildErrorInfoFrom: hDBC type: SQL_HANDLE_DBC].
 			hStmt isNull ifFalse: [self buildErrorInfoFrom: hStmt type: SQL_HANDLE_STMT]].
-	errors isNil ifTrue: [self retCodeError: code].
+	errors ifNil: [self retCodeError: code]
 ]
 
 { #category : #operations }
@@ -171,10 +171,9 @@ ODBCExceptionDetails >> initialize [
 ODBCExceptionDetails >> printOn: aStream [
 	"Print an textual representation of the receiver to aStream"
 
-	self errors 
-		do: [ :e | aStream print: e messageText]
-		separatedBy: [aStream space]
-
+	self errors
+		do: [ :e | aStream print: e messageText ]
+		separatedBy: [ aStream space ]
 ]
 
 { #category : #accessing }
@@ -191,10 +190,12 @@ ODBCExceptionDetails >> retCodeError: anInteger [
 
 { #category : #accessing }
 ODBCExceptionDetails >> stringEncoder [
+
 	^ stringEncoder
 ]
 
 { #category : #accessing }
 ODBCExceptionDetails >> stringEncoder: anObject [
+
 	stringEncoder := anObject
 ]

--- a/ODBC-Core/ODBCField.class.st
+++ b/ODBC-Core/ODBCField.class.st
@@ -36,7 +36,7 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
-{ #category : #initializing }
+{ #category : #'class initialization' }
 ODBCField class >> initialize [
 	"Initialize the dictionaries of to/from
 	C Type/Smalltalk object converters.
@@ -143,6 +143,7 @@ ODBCField >> bufferSize [
 
 { #category : #accessing }
 ODBCField >> column [
+
 	^column
 ]
 
@@ -566,14 +567,16 @@ ODBCField >> value [
 	"Answer the contents of the receiver as a suitable
 	Smalltalk object."
 
-	^self isNull ifFalse: [self perform: (GetSelectors at: column type + TypeOffset)]
+	^ self isNull ifFalse: [ 
+		  self perform: (GetSelectors at: column type + TypeOffset) ]
 ]
 
 { #category : #accessing }
 ODBCField >> value: anObject [
 	"Set the contents of the receiver's buffer from anObject."
 
-	^anObject
-		ifNil: [self beNull]
-		ifNotNil: [self perform: (SetSelectors at: column type + TypeOffset) with: anObject]
+	^ anObject ifNil: [ self beNull ] ifNotNil: [ 
+		  self
+			  perform: (SetSelectors at: column type + TypeOffset)
+			  with: anObject ]
 ]

--- a/ODBC-Core/ODBCForwardOnlyResultSet.class.st
+++ b/ODBC-Core/ODBCForwardOnlyResultSet.class.st
@@ -24,7 +24,7 @@ ODBCForwardOnlyResultSet >> bind: anArrayOfColNums [
 	as they are fetched from the result set"
 
 	super bind: anArrayOfColNums.
-	position := 0.
+	position := 0
 ]
 
 { #category : #'realizing/unrealizing' }
@@ -44,7 +44,7 @@ ODBCForwardOnlyResultSet >> free [
 	position := 0
 ]
 
-{ #category : #operations }
+{ #category : #positioning }
 ODBCForwardOnlyResultSet >> moveFirst [
 	"Private - If not at the start of the result set, then re-exec the statement."
 
@@ -55,7 +55,7 @@ ODBCForwardOnlyResultSet >> moveFirst [
 			self moveNext]
 ]
 
-{ #category : #enumerating }
+{ #category : #positioning }
 ODBCForwardOnlyResultSet >> moveLast [
 	"Private - Scroll to the last row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -65,7 +65,7 @@ ODBCForwardOnlyResultSet >> moveLast [
 	^lastStatus
 ]
 
-{ #category : #operations }
+{ #category : #positioning }
 ODBCForwardOnlyResultSet >> moveNext [
 	"Private - Advance to the next row in the result set."
 
@@ -75,7 +75,7 @@ ODBCForwardOnlyResultSet >> moveNext [
 	^status
 ]
 
-{ #category : #enumerating }
+{ #category : #positioning }
 ODBCForwardOnlyResultSet >> movePrevious [
 	"Private - Scroll to the previous row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -83,7 +83,7 @@ ODBCForwardOnlyResultSet >> movePrevious [
 	self moveTo: position - 1
 ]
 
-{ #category : #accessing }
+{ #category : #positioning }
 ODBCForwardOnlyResultSet >> moveTo: anInteger [ 
 	| status |
 	position = anInteger 

--- a/ODBC-Core/ODBCResultSet.class.st
+++ b/ODBC-Core/ODBCResultSet.class.st
@@ -463,6 +463,7 @@ ODBCResultSet >> lastIndexOf: target [
 
 { #category : #accessing }
 ODBCResultSet >> lookup: keyInteger [
+
 	^self at: keyInteger
 ]
 
@@ -504,16 +505,16 @@ ODBCResultSet >> moveTo: anInteger [
 	row (requires extended fetch capability),
 	and answer the status."
 
-	^anInteger == 1 
-		ifTrue: [self moveFirst]
-		ifFalse: [self scrollTo: anInteger]
+	^ anInteger == 1
+		  ifTrue: [ self moveFirst ]
+		  ifFalse: [ self scrollTo: anInteger ]
 ]
 
 { #category : #accessing }
 ODBCResultSet >> next [
 	"Answer the next row of the receiver's result set, skipping any deleted rows."
 
-	^self moveNext isNil ifFalse: [buffer asObject]
+	^self moveNext ifNotNil: [buffer asObject]
 ]
 
 { #category : #accessing }
@@ -542,7 +543,7 @@ ODBCResultSet >> onStartup [
 ODBCResultSet >> previous [
 	"Answer the previous row of the receiver's result set"
 
-	^self movePrevious isNil ifFalse: [buffer asObject]
+	^self movePrevious ifNotNil: [buffer asObject]
 ]
 
 { #category : #printing }
@@ -554,7 +555,7 @@ ODBCResultSet >> printOn: aStream [
 		print: self class; space;
 		nextPut: $(;
 		print: self describeCols;
-		nextPut: $).
+		nextPut: $)
 ]
 
 { #category : #enumerating }
@@ -626,6 +627,7 @@ ODBCResultSet >> reverseDo: operation [
 
 { #category : #accessing }
 ODBCResultSet >> scrollTo: anInteger [
+
 	^self fetchScroll: SQL_FETCH_ABSOLUTE offset: anInteger
 ]
 
@@ -692,9 +694,8 @@ ODBCResultSet >> statementHandle [
 
 	| hStmt |
 	hStmt := statement executedHandle.
-	buffer isNil ifTrue: [self realize].
-	^hStmt
-
+	buffer ifNil: [ self realize ].
+	^ hStmt
 ]
 
 { #category : #enumerating }

--- a/ODBC-Core/ODBCRow.class.st
+++ b/ODBC-Core/ODBCRow.class.st
@@ -19,14 +19,15 @@ ODBCRow class >> fromBuffer: anODBCRow [
 ODBCRow >> asObject [
 	"Private - Answer the receiver as an instance of ODBCRow containing the receiver's values."
 
-	^self
+	^ self
 ]
 
 { #category : #'instance creation' }
 ODBCRow >> initializeFromBuffer: anODBCRow [
+
 	columns := anODBCRow columns.
 	selectors := anODBCRow selectors.
 	contents := anODBCRow objects.
 	status := anODBCRow status.
-	^self
+	^ self
 ]

--- a/ODBC-Core/ODBCRowBuffer.class.st
+++ b/ODBC-Core/ODBCRowBuffer.class.st
@@ -13,7 +13,7 @@ Class {
 ODBCRowBuffer >> asObject [
 	"Private - Answer the receiver as an instance of ODBCRow containing the receiver's values."
 
-	^ODBCRow fromBuffer: self
+	^ ODBCRow fromBuffer: self
 ]
 
 { #category : #operations }
@@ -22,7 +22,7 @@ ODBCRowBuffer >> bind: aDBStatement [
 
 	| hStmt |
 	hStmt := aDBStatement executedHandle.
-	#todo "Will need an array of status values if to fetch a block of rows at a time".
+	self flag: #TODO. "Will need an array of status values if to fetch a block of rows at a time".
 	status := SQLUSMALLINT new.
 	aDBStatement statusArray: status.
 	^hStmt
@@ -32,9 +32,8 @@ ODBCRowBuffer >> bind: aDBStatement [
 ODBCRowBuffer >> contents [
 	"Answer the contents instance variable."
 
-	contents isNil
-		ifTrue: [contents := columns collect: [:colAttr | ODBCField newForCol: colAttr]].
-	^contents.
+	contents ifNil: [ contents := columns collect: [:colAttr | ODBCField newForCol: colAttr ]].
+	^contents
 ]
 
 { #category : #accessing }
@@ -42,17 +41,18 @@ ODBCRowBuffer >> objects [
 	"Private - Answer the receivers contents as an <Array> of <Object>s
 	representing the value of each column."
 
-	^self contents collect: [:c | c value]
+	^ self contents collect: [:c | c value ]
 ]
 
 { #category : #accessing }
 ODBCRowBuffer >> sizeInBytes [
 	"Answer the size of the receiver structure in bytes."
 
-	 ^self contents inject: 0 into: [ :size :f | size + f size ].
+	 ^self contents inject: 0 into: [:size :f | size + f size ]
 ]
 
 { #category : #accessing }
 ODBCRowBuffer >> status [
+
 	^status value
 ]

--- a/ODBC-Core/ODBCSchemaStatement.class.st
+++ b/ODBC-Core/ODBCSchemaStatement.class.st
@@ -14,6 +14,12 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
+{ #category : #testing }
+ODBCSchemaStatement class >> isAbstract [
+
+	^ self == ODBCSchemaStatement
+]
+
 { #category : #accessing }
 ODBCSchemaStatement >> catalogName [
 	^catalogName
@@ -31,6 +37,14 @@ ODBCSchemaStatement >> defaultCursorType [
 
 	^#forwardOnly
 
+]
+
+{ #category : #operations }
+ODBCSchemaStatement >> executeStatement [
+	"Private - Execute the database command that the receiver represents.
+	Answer the <integer> return code."
+
+	^self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/ODBC-Core/ODBCStringEncoder.class.st
+++ b/ODBC-Core/ODBCStringEncoder.class.st
@@ -10,6 +10,12 @@ Class {
 	#category : #'ODBC-Core-Base'
 }
 
+{ #category : #testing }
+ODBCStringEncoder class >> isAbstract [
+
+	^ self == ODBCStringEncoder
+]
+
 { #category : #encoding }
 ODBCStringEncoder >> byteSizeForCharacters: anInteger [
 
@@ -30,7 +36,6 @@ ODBCStringEncoder >> bytesPerCharacter [
 
 { #category : #accessing }
 ODBCStringEncoder >> characterEncoder [
-
 	"Appears to lose endian-ness (at image start?) so always reset"
 	
 	^characterEncoder beLittleEndian
@@ -82,7 +87,6 @@ ODBCStringEncoder >> initialize [
 
 { #category : #constants }
 ODBCStringEncoder >> nullTerminatorBytes [
-
 	"Should be size == self bytesPerCharacter"
 	
 	^self subclassResponsibility
@@ -90,7 +94,6 @@ ODBCStringEncoder >> nullTerminatorBytes [
 
 { #category : #encoding }
 ODBCStringEncoder >> stringBufferFor: anInteger [
-
 	"Create, allocate and return a buffer (ExternalAddress) to hold anInteger characters in the receiver's encoding"
 	
 	"For convenience always add 1 for a null terminator - allows this method to be used for all String API calls"

--- a/ODBC-Core/ODBCTxn.class.st
+++ b/ODBC-Core/ODBCTxn.class.st
@@ -78,7 +78,7 @@ ODBCTxn >> connection [
 ODBCTxn >> connection: anODBCConnection [
 	"Private - Set the connection instance variable to anODBCConnection."
 
-	connection := anODBCConnection.
+	connection := anODBCConnection
 ]
 
 { #category : #development }
@@ -100,8 +100,9 @@ ODBCTxn >> printOn: aStream [
 			ifTrue: ['disabled']
 			ifFalse: ['enabled']);
 		nextPutAll: connection dsn;
-		nextPutAll: ', belonging to: ';
-		nextPutAll: creator printString;
+		nextPutAll: ', belonging to: '.
+	creator printOn: aStream.
+	aStream	
 		nextPut: $)
 ]
 
@@ -119,11 +120,10 @@ ODBCTxn >> transcriptMessage: aString [
 	"Private - Output an appropriately annotated message to the current
 	session's trace device. In a development session this is the Transcript"
 
-	creator notNil
-		ifTrue: 
-			[Transcript
-				print: self;
-				space;
-				nextPutAll: aString;
-				cr]
+	creator ifNotNil: [ 
+		Transcript
+			print: self;
+			space;
+			nextPutAll: aString;
+			cr ]
 ]

--- a/ODBC-Core/ODBCUTF16Encoder.class.st
+++ b/ODBC-Core/ODBCUTF16Encoder.class.st
@@ -21,7 +21,6 @@ ODBCUTF16Encoder >> characterEncoderClass [
 
 { #category : #decoding }
 ODBCUTF16Encoder >> decodeNullTerminatedStringFrom: aByteArray [
-
 	"Optimised (~25% faster) equivalent of superclass implementation"
 
 	| stream offset |
@@ -51,7 +50,6 @@ ODBCUTF16Encoder >> decodeNullTerminatedStringFrom: aByteArray [
 
 { #category : #decoding }
 ODBCUTF16Encoder >> decodeStringFrom: aByteArray byteCount: anInteger [
-
 	"Optimised (~25% faster) equivalent of superclass implementation"
 
 	| stream offset |
@@ -83,5 +81,5 @@ ODBCUTF16Encoder >> decodeStringFrom: aByteArray byteCount: anInteger [
 { #category : #constants }
 ODBCUTF16Encoder >> nullTerminatorBytes [
 
-	^#[0 0]
+	^#[ 0 0 ]
 ]

--- a/ODBC-Core/ODBCUTF32Encoder.class.st
+++ b/ODBC-Core/ODBCUTF32Encoder.class.st
@@ -22,5 +22,5 @@ ODBCUTF32Encoder >> characterEncoderClass [
 { #category : #constants }
 ODBCUTF32Encoder >> nullTerminatorBytes [
 
-	^#[0 0 0 0]
+	^#[ 0 0 0 0 ]
 ]

--- a/ODBC-Core/ODBCWarning.class.st
+++ b/ODBC-Core/ODBCWarning.class.st
@@ -16,13 +16,6 @@ ODBCWarning class >> signalWith: anODBCExceptionDetails [
 	self signal: anODBCExceptionDetails displayString withTag: anODBCExceptionDetails
 ]
 
-{ #category : #displaying }
-ODBCWarning >> _descriptionFormat [
-	"Answer the Win32 format String to be used to format the description for the receiver."
-	
-	^'%1 %2'
-]
-
 { #category : #signalling }
 ODBCWarning >> signal [
 	"Signal this exception."


### PR DESCRIPTION
Fix #1 

- use "self flag: #TODO." instead of #todo  (for instance in ODBCRowBuffer>>#bind:) which is also honored with special category in Calypso browser
- use ifNil: instead of isNil ifTrue:
- use ifNil:ifNotNil: instead of isNil ifTrue: ifFalse:
- remove unused dots at end of methods
- implement missing ODBCSchemaStatement>>#executeStatement (lint violation)
- remove unnecessary "self initialize" comments (Pharo has a clickable icon in Calypso to call it, no need to have such expression in comments)
- implement ODBCAbstractStatement class>>#isAbstract to return true
- implement ODBCSchemaStatement class>>#isAbstract to return true
- implement ODBCAbstractRow class>>#isAbstract
- implement ODBCStringEncoder class>>#isAbstract
- no need for #yourself call in ODBCColFlags class>>#initialize
- Use standard category "class initialization" for class side #initialize methods
- put other private initializers into standard method category "private - initialization" category
- use chaining in ODBCConnection class>>#freeAll to simplify
- remove unused ODBCWarning>>#_descriptionFormat and unused ODBCError>>#_descriptionFormat (if we still need it it would be better placed in class comment)
- fix lint problem in ODBCTxn>>#printOn: by using "creator printOn: aStream" 
- fix inconsistent method classification of ODBCForwardOnlyResultSet>>#moveFirst, #moveLast, #moveNext, #movePrevious, #moveTo: compared to superclass
- simplify ODBCConnection>>#close (guardian clause)
- simplify ODBCConnection>>#checkEmptyEnvironment (guardian clause)
- ODBCRow>>#initializeFromBuffer: should be in "private - initialization" (although it is called during instance creation
  it would otherwise be strange to have an instance side "instance creation" protocol
- format code