### PR TITLE
Cleanup ODBC-Tests package

### DIFF
--- a/ODBC-Tests/AccessNorthwindDB.class.st
+++ b/ODBC-Tests/AccessNorthwindDB.class.st
@@ -1,13 +1,16 @@
+"
+Provides access to Northwind Test database using Microsoft Access for tests as a reusable test resource
+"
 Class {
 	#name : #AccessNorthwindDB,
 	#superclass : #ODBCConnectionTestResource,
 	#instVars : [
 		'filename'
 	],
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Resources'
 }
 
-{ #category : #constants }
+{ #category : #'accessing - constants' }
 AccessNorthwindDB class >> accessDriverName [
 	
 	ODBCConnection enumerateDrivers do: [ :assoc | (assoc key beginsWith: 'Microsoft Access Driver (*.mdb') ifTrue: [ ^assoc key ]].
@@ -16,7 +19,7 @@ AccessNorthwindDB class >> accessDriverName [
 
 ]
 
-{ #category : #constants }
+{ #category : #'accessing - constants' }
 AccessNorthwindDB class >> connectStringPattern [
 
 	^'DRIVER={', self accessDriverName, '};DBQ=<1s>'

--- a/ODBC-Tests/AccessODBCTest.class.st
+++ b/ODBC-Tests/AccessODBCTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #AccessODBCTest,
 	#superclass : #ODBCConnectionTest,
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Base'
 }
 
 { #category : #public }

--- a/ODBC-Tests/ManifestDatabaseTests.class.st
+++ b/ODBC-Tests/ManifestDatabaseTests.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ManifestDatabaseTests,
-	#superclass : #PackageManifest,
-	#category : #'ODBC-Tests-Manifest'
-}

--- a/ODBC-Tests/ODBCConnectionTest.class.st
+++ b/ODBC-Tests/ODBCConnectionTest.class.st
@@ -10,13 +10,13 @@ Class {
 		'ODBCConstants',
 		'ODBCTypes'
 	],
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Base'
 }
 
 { #category : #testing }
 ODBCConnectionTest class >> isAbstract [
 
-	^self = ODBCConnectionTest
+	^self == ODBCConnectionTest
 ]
 
 { #category : #public }

--- a/ODBC-Tests/ODBCConnectionTestResource.class.st
+++ b/ODBC-Tests/ODBCConnectionTestResource.class.st
@@ -1,3 +1,6 @@
+"
+Common superclass for ODBC test resources
+"
 Class {
 	#name : #ODBCConnectionTestResource,
 	#superclass : #TestResource,
@@ -5,21 +8,30 @@ Class {
 		'connection',
 		'isAvailable'
 	],
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Resources'
 }
+
+{ #category : #testing }
+ODBCConnectionTestResource class >> isAbstract [
+
+	^ self == ODBCConnectionTestResource
+]
 
 { #category : #private }
 ODBCConnectionTestResource >> connect [
+
 	connection := self newConnection
 ]
 
 { #category : #private }
 ODBCConnectionTestResource >> connectString [
+
 	self subclassResponsibility
 ]
 
 { #category : #private }
 ODBCConnectionTestResource >> connection [
+
 	^connection
 ]
 
@@ -32,14 +44,15 @@ ODBCConnectionTestResource >> createDatabase [
 
 { #category : #private }
 ODBCConnectionTestResource >> dropDatabase [
-	connection
-		ifNotNil: 
-			[connection close.
-			connection := nil]
+
+	connection ifNotNil: [ 
+		connection close.
+		connection := nil ]
 ]
 
 { #category : #public }
 ODBCConnectionTestResource >> newConnection [
+
 	^isAvailable
 		ifTrue: 
 			[(ODBCConnection new connectString: self connectString)
@@ -47,12 +60,16 @@ ODBCConnectionTestResource >> newConnection [
 				yourself]
 ]
 
-{ #category : #public }
+{ #category : #running }
 ODBCConnectionTestResource >> setUp [
-	(isAvailable := self createDatabase) ifTrue: [self connect]
+
+	super setUp.
+	(isAvailable := self createDatabase) ifTrue: [ self connect ]
 ]
 
-{ #category : #public }
+{ #category : #running }
 ODBCConnectionTestResource >> tearDown [
-	self dropDatabase
+
+	self dropDatabase.
+	super tearDown 
 ]

--- a/ODBC-Tests/ODBCTest.class.st
+++ b/ODBC-Tests/ODBCTest.class.st
@@ -4,13 +4,13 @@ Class {
 	#instVars : [
 		'connection'
 	],
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Base'
 }
 
 { #category : #testing }
 ODBCTest class >> isAbstract [ 
 
-	^self = ODBCTest
+	^self == ODBCTest
 ]
 
 { #category : #helpers }
@@ -37,9 +37,9 @@ ODBCTest >> setUp [
 
 { #category : #helpers }
 ODBCTest >> skipUnless: aNiladicValuable [
-	" If the assumption in the <niladicValuable> argument evaluates to false, abandon the running test and mark it as skipped."
+	"If the assumption in the <niladicValuable> argument evaluates to false, abandon the running test and mark it as skipped."
 	
-	aNiladicValuable value ifFalse: [TestSkip signal: 'Assumption in #skipUnless: failed']
+	aNiladicValuable value ifFalse: [ self skip: 'Assumption in #skipUnless: failed' ]
 ]
 
 { #category : #running }

--- a/ODBC-Tests/SQLServerNorthwindDB.class.st
+++ b/ODBC-Tests/SQLServerNorthwindDB.class.st
@@ -1,10 +1,13 @@
+"
+Access to Northwind Test database using Microsoft SQL Server for tests as a reusable test resource
+"
 Class {
 	#name : #SQLServerNorthwindDB,
 	#superclass : #ODBCConnectionTestResource,
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Resources'
 }
 
-{ #category : #private }
+{ #category : #'private - accessing' }
 SQLServerNorthwindDB >> connectString [
 	"Private - APPVEYOR config is 'DRIVER=SQL Server;Server=(local)\SQL2017;Database=master;User ID=sa;Password=Password12!'"
 
@@ -49,17 +52,17 @@ SQLServerNorthwindDB >> newConnection [
 				yourself]
 ]
 
-{ #category : #private }
+{ #category : #'private - credentials' }
 SQLServerNorthwindDB >> pwd [
 	^'Password12!'
 ]
 
-{ #category : #private }
+{ #category : #'private - accessing' }
 SQLServerNorthwindDB >> serverName [
 	^'(local)\SQL2019'
 ]
 
-{ #category : #private }
+{ #category : #'private - credentials' }
 SQLServerNorthwindDB >> uid [
 	^'sa'
 ]

--- a/ODBC-Tests/SQLServerODBCTest.class.st
+++ b/ODBC-Tests/SQLServerODBCTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SQLServerODBCTest,
 	#superclass : #ODBCConnectionTest,
-	#category : #'ODBC-Tests'
+	#category : #'ODBC-Tests-Base'
 }
 
 { #category : #public }


### PR DESCRIPTION
Fix #6

- remove manifest class ManifestDatabaseTests (its missnamed and empty)
- do not use missing unknown class "TestSkip" but instead Pharos SUnit #skip: method in ODBCTest>>#skipUnless:
- setUp and tearDown for the test resources need to call super methods (similar to test method)
- formatting
- properly categorize methods (for instance setUp and tearDown in running following SUnit standard)
- provide ODBCConnectionTestResource class>>#isAbstract to return true
- use == instead of = in other isAbstract methods